### PR TITLE
Get rid of npm-run-all

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "clean": "rimraf lib",
     "build": "webpack",
-    "prepare": "npx npm-run-all clean build"
+    "prepare": "yarn clean && yarn build"
   },
   "activationEvents": [
     "onLanguage:html",


### PR DESCRIPTION
`npm-run-all` is broken with npm 7 and haven't updated for 2 years.

###### Reference
- https://github.com/neoclide/coc-tsserver/pull/234