### PR TITLE
fix(settings): implicitProjectConfig maybe undefined

### DIFF
--- a/server/modes/javascriptMode.ts
+++ b/server/modes/javascriptMode.ts
@@ -84,7 +84,7 @@ export function getJavaScriptMode(documentRegions: LanguageModelCache<HTMLDocume
 			return languageId;
 		},
 		async doValidation(document: TextDocument, settings = workspace.settings): Promise<Diagnostic[]> {
-			host.getCompilationSettings()['experimentalDecorators'] = settings && settings.javascript && settings.javascript.implicitProjectConfig.experimentalDecorators;
+			host.getCompilationSettings()['experimentalDecorators'] = settings && settings.javascript && settings.javascript.implicitProjectConfig && settings.javascript.implicitProjectConfig.experimentalDecorators;
 			const jsDocument = jsDocuments.get(document);
 			const languageService = await host.getLanguageService(jsDocument);
 			const syntaxDiagnostics: ts.Diagnostic[] = languageService.getSyntacticDiagnostics(jsDocument.uri);


### PR DESCRIPTION
fix implicitProjectConfig maybe undefined

```
[Error  - 11:08:17 AM] Error while validating file:///Users/yuuko/workspace/pxn/anduin/html.html: Cannot read property 'experimentalDecorators' of undefined
TypeError: Cannot read property 'experimentalDecorators' of undefined
    at Object.<anonymous> (/Users/yuuko/.config/coc/extensions/node_modules/coc-html/lib/server.js:64143:152)
    at Generator.next (<anonymous>)
    at /Users/yuuko/.config/coc/extensions/node_modules/coc-html/lib/server.js:64067:71
    at new Promise (<anonymous>)
    at __awaiter (/Users/yuuko/.config/coc/extensions/node_modules/coc-html/lib/server.js:64063:12)
    at Object.doValidation (/Users/yuuko/.config/coc/extensions/node_modules/coc-html/lib/server.js:64142:20)
    at /Users/yuuko/.config/coc/extensions/node_modules/coc-html/lib/server.js:7990:74
    at Generator.next (<anonymous>)
    at fulfilled (/Users/yuuko/.config/coc/extensions/node_modules/coc-html/lib/server.js:7770:58)

```