### PR TITLE
feat: support other filetypes set in "html.filetypes" with autoInsertion

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -102,7 +102,8 @@ function realActivate(context: ExtensionContext, filetypes: string[]) {
       }
       return client.sendRequest(AutoInsertRequest.type, param)
     }
-    activateAutoInsertion(insertRequestor, { html: true, handlebars: true }, context.subscriptions)
+    const autoInsertionSupportedLanguages: { [id: string]: boolean } = Object.assign({}, ...filetypes.map((id) => ({ [id]: true })));
+    activateAutoInsertion(insertRequestor, autoInsertionSupportedLanguages, context.subscriptions)
 
     if (typeof languages.registerDocumentSemanticTokensProvider === 'function') {
       client.sendRequest(SemanticTokenLegendRequest.type).then(legend => {


### PR DESCRIPTION
Currently, only `html` and `handlebars` are enable, but I have changed it to refer to the `html.filetypes` setting.